### PR TITLE
FPVTL-2883: upgrade to Java 21 and java-logging 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG APP_INSIGHTS_AGENT_VERSION=3.2.8
-FROM hmctspublic.azurecr.io/base/java:17-distroless
+ARG APP_INSIGHTS_AGENT_VERSION=3.7.1
+FROM hmctsprod.azurecr.io/base/java:21-distroless
 
 COPY lib/applicationinsights.json /opt/app/
 COPY build/libs/fis-bulk-scan-api.jar /opt/app/

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ spotless {
 
 java {
 toolchain {
-	languageVersion = JavaLanguageVersion.of(17)
+	languageVersion = JavaLanguageVersion.of(21)
 }
 }
 
@@ -206,7 +206,7 @@ springfoxSwagger  : '3.0.0',
 s2sClient         : '4.0.3',
 springCloud       : '3.1.9',
 commonsIo         :  '2.7',
-reformsJavaLogging: '6.1.9'
+reformsJavaLogging: '8.0.0'
 ]
 
 ext {
@@ -241,13 +241,7 @@ implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-clie
 
 implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.8.0'
 
-//implementation group: 'uk.gov.hmcts.reform', name: 'logging', version: versions.reformsJavaLogging
-//implementation group: 'uk.gov.hmcts.reform', name: 'logging-appinsights', version: versions.reformsJavaLogging
-//implementation group: 'uk.gov.hmcts.reform', name: 'logging-spring', version: versions.reformsJavaLogging
 implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: versions.reformsJavaLogging
-implementation group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: versions.reformsJavaLogging
-
-implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '6.1.9'
 
 implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: log4JVersion
 implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: log4JVersion

--- a/build.gradle
+++ b/build.gradle
@@ -195,10 +195,10 @@ analyzers {
 }
 
 repositories {
-mavenLocal()
-mavenCentral()
-maven { url 'https://jitpack.io' }
-jcenter()
+  maven {
+    url = uri("https://pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/maven/v1")
+  }
+  gradlePluginPortal()
 }
 
 def versions = [

--- a/charts/fis-bulk-scan-api/Chart.yaml
+++ b/charts/fis-bulk-scan-api/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 dependencies:
   - name: java
     version: 5.3.0
-    repository: 'oci://hmctspublic.azurecr.io/helm'
+    repository: 'oci://hmctsprod.azurecr.io/helm'

--- a/charts/fis-bulk-scan-api/Chart.yaml
+++ b/charts/fis-bulk-scan-api/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for fis-bulk-scan-api App
 name: fis-bulk-scan-api
 home: https://github.com/hmcts/fis-bulk-scan-api
-version: 0.0.10
+version: 0.0.11
 maintainers:
   - name: HMCTS fis team
 dependencies:

--- a/charts/fis-bulk-scan-api/values.yaml
+++ b/charts/fis-bulk-scan-api/values.yaml
@@ -1,6 +1,6 @@
 java:
   applicationPort: 8090
-  image: 'hmctspublic.azurecr.io/fis/bulk-scan-api:latest'
+  image: 'hmctsprod.azurecr.io/fis/bulk-scan-api:latest'
   ingressHost: fis-bulk-scan-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
   aadIdentityName: fis
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
         - http_proxy
         - https_proxy
         - no_proxy
-    image: hmctspublic.azurecr.io/spring-boot/template
+    image: hmctsprod.azurecr.io/spring-boot/template
     environment:
       # these environment variables are used by java-logging library
       - ROOT_APPENDER


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FPVTL-2883

### Change description ###

Upgrade to Java 21

Upgrade to java-logging 8 because all previous versions will become outdated and PRs would not build after 01/06/2026 
In versions prior to 7.x, there was a separate dependency for appinsights. This is part of the main dependency since 7.0.0. That line has been removed here because java-logging was at version 6.1.9

These are the instructions to upgrade from 6.x: https://github.com/hmcts/java-logging See the readme file there.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```